### PR TITLE
Fixed signature path for Outlook 2016

### DIFF
--- a/OutlookSignatureScript.ps1
+++ b/OutlookSignatureScript.ps1
@@ -111,7 +111,14 @@ try
     }
     
     # get the localised name for the "Signatures" folder and build the path
-    $SignatureFolderName = (Get-ItemProperty -Path "HKCU:\Software\Microsoft\Office\$OutlookVersion.0\Common\General").Signatures
+    if ($OutlookVersion -eq 16)
+	{
+		$SignatureFolderName = (Get-ItemProperty -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Office\$OutlookVersion.0\User Settings\Mso_CoreReg\Create\Software\Microsoft\Office\$OutlookVersion.0\Common\General").Signatures
+	}
+    else
+    {
+	$SignatureFolderName = (Get-ItemProperty -Path "HKCU:\Software\Microsoft\Office\$OutlookVersion.0\Common\General").Signatures
+    }
     $OutlookSignaturePath = $env:APPDATA+'\Microsoft\'+$SignatureFolderName
     
     $Events = [System.Collections.ArrayList]@()


### PR DESCRIPTION
The path to fetch Signatures folder name is different in Outlook 2016. I've testet this on Outlook 2016, and it works.